### PR TITLE
feature: auto registry projects in sidebar

### DIFF
--- a/docs/zh/_sidebar.md
+++ b/docs/zh/_sidebar.md
@@ -14,6 +14,7 @@
   - [sentinel-dashboard](zh/usage/sentinel-dashboard)
   - [sentinel-客户端](zh/usage/sentinel-client)
   - [Apollo开放平台](zh/usage/apollo-open-api)
+  - [Apollo控制台](zh/usage/apollo-portal)
 
 - FAQ
   - [错误信息](zh/faq/error-message)

--- a/docs/zh/usage/apollo-portal.md
+++ b/docs/zh/usage/apollo-portal.md
@@ -1,0 +1,155 @@
+# Apollo Portal
+
+sentinel的控制台为了方便运维，提供了直接调用Apollo Portal（Apollo的控制台）的功能
+
+在输入Cookie后，可以直接调用Apollo Portal进行一系列的授权操作，避开麻烦的人工操作
+
+这里做一个HTTP接口的记录
+
+Sentinel控制台主要用的是[赋权](#赋权)
+
+## 开放平台授权管理
+
+参考源码https://github.com/ctripcorp/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConsumerController.java
+
+以及根据浏览器调试，获取相关信息，整理出如下接口
+
+### 查询第三方应用ID是否存在
+
+#### 请求
+
+HTTP GET
+
+URL
+
+```
+consumers/by-appId?appId={appId}
+```
+
+`{appId}`替换成具体的名字
+
+例如
+
+```
+consumers/by-appId?appId=abcd
+```
+
+#### 响应
+
+##### 未创建
+
+如果第三方应用未创建，会没有response data
+
+##### 已创建
+
+如果第三方应用已经被创建，会返回类似如下的response data
+
+```json
+{
+  "consumerId": 3,
+  "token": "fbe414f685ffe5fbc891ea146f4997a664db3bf1",
+  "expires": "2099-01-01T00:00:00.000+0800",
+  "id": 3,
+  "isDeleted": false,
+  "dataChangeCreatedBy": "apollo",
+  "dataChangeCreatedTime": "2021-04-08T22:59:29.000+0800",
+  "dataChangeLastModifiedBy": "apollo",
+  "dataChangeLastModifiedTime": "2021-04-08T22:59:29.000+0800"
+}
+```
+
+### 创建第三方应用
+
+#### 请求
+
+HTTP POST
+
+URL
+
+```
+consumers
+```
+
+Request Body
+
+```json
+{
+  "appId": "abc",
+  "name": "abc-server",
+  "orgId": "TEST1",
+  "orgName": "样例部门1",
+  "ownerName": "apollo"
+}
+```
+
+| json string | 说明           |
+| ----------- | -------------- |
+| appId       | 第三方应用ID   |
+| name        | 第三方应用名称 |
+| orgId       | 部门（Id）     |
+| orgName     | 部门（名字）   |
+| ownerName   | 项目负责人     |
+
+#### 响应
+
+Response Body
+
+```json
+{
+  "consumerId": 3,
+  "token": "fbe414f685ffe5fbc891ea146f4997a664db3bf1",
+  "expires": "2099-01-01T00:00:00.000+0800",
+  "id": 3,
+  "isDeleted": false,
+  "dataChangeCreatedBy": "apollo",
+  "dataChangeCreatedTime": "2021-04-08T22:59:28.594+0800",
+  "dataChangeLastModifiedBy": "apollo",
+  "dataChangeLastModifiedTime": "2021-04-08T22:59:28.594+0800"
+}
+```
+
+### 赋权
+
+授权类型是**App**（为了可以自动创建集群）
+
+#### 请求
+
+HTTP POST
+
+URL
+
+```
+consumers/{token}/assign-role?type=AppRole
+```
+
+例如
+
+```
+consumers/58bb334437c20e55b86329d4238cd5baf4d4d420/assign-role?type=AppRole
+```
+
+Request Body
+
+```json
+{"appId":"test"}
+```
+
+#### 响应
+
+只有1个element的json array
+
+```json
+[
+  {
+    "consumerId": 2,
+    "roleId": 2,
+    "id": 7,
+    "isDeleted": false,
+    "dataChangeCreatedBy": "apollo",
+    "dataChangeCreatedTime": "2021-03-30T21:25:10.000+0800",
+    "dataChangeLastModifiedBy": "apollo",
+    "dataChangeLastModifiedTime": "2021-03-30T21:25:10.000+0800"
+  }
+]
+```
+

--- a/sentinel-dashboard/pom.xml
+++ b/sentinel-dashboard/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>sentinel-dashboard</artifactId>
     <packaging>jar</packaging>
-    <version>1.8.1-1-RELEASE</version>
+    <version>1.8.1-2-SNAPSHOT</version>
 
     <properties>
         <resource.delimiter>@</resource.delimiter>

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/config/SentinelApolloConfiguration.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/config/SentinelApolloConfiguration.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.dashboard.apollo.config;
 
 import com.alibaba.csp.sentinel.dashboard.apollo.repository.project.ApolloProjectStore;
 import com.alibaba.csp.sentinel.dashboard.apollo.repository.project.ProjectRepository;
+import com.alibaba.csp.sentinel.dashboard.apollo.service.ApolloPortalService;
 import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelApolloService;
 import com.alibaba.csp.sentinel.dashboard.apollo.service.impl.DefaultSentinelApolloServiceImpl;
 import com.ctrip.framework.apollo.openapi.client.ApolloOpenApiClient;
@@ -36,20 +37,28 @@ public class SentinelApolloConfiguration {
 
     private final SentinelApolloProperties sentinelApolloProperties;
 
+    private final ApolloPortalService apolloPortalService;
+
     public SentinelApolloConfiguration(
             SentinelApolloOpenApiProperties sentinelApolloOpenApiProperties,
             ApolloOpenApiClient apolloOpenApiClient,
-            SentinelApolloProperties sentinelApolloProperties
-    ) {
+            SentinelApolloProperties sentinelApolloProperties,
+            ApolloPortalService apolloPortalService) {
         this.sentinelApolloOpenApiProperties = sentinelApolloOpenApiProperties;
         this.apolloOpenApiClient = apolloOpenApiClient;
         this.sentinelApolloProperties = sentinelApolloProperties;
+        this.apolloPortalService = apolloPortalService;
     }
 
     @Bean
     @ConditionalOnMissingBean
     public SentinelApolloService sentinelApolloService() {
-        return new DefaultSentinelApolloServiceImpl(this.sentinelApolloOpenApiProperties, this.apolloOpenApiClient, this.sentinelApolloProperties);
+        return new DefaultSentinelApolloServiceImpl(
+                this.sentinelApolloOpenApiProperties,
+                this.apolloOpenApiClient,
+                this.sentinelApolloProperties,
+                this.apolloPortalService
+        );
     }
 
     @Bean

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/BaseEntity.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/BaseEntity.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.entity;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author wxq
+ * @see <a href="https://github.com/ctripcorp/apollo/blob/master/apollo-common/src/main/java/com/ctrip/framework/apollo/common/entity/BaseEntity.java">com/ctrip/framework/apollo/common/entity/BaseEntity</a>
+ */
+public abstract class BaseEntity {
+
+    private Long id;
+
+    private Boolean isDeleted;
+
+    private String dataChangeCreatedBy;
+
+    private Date dataChangeCreatedTime;
+
+    private String dataChangeLastModifiedBy;
+
+    private Date dataChangeLastModifiedTime;
+
+    protected MoreObjects.ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this).omitNullValues().add("id", id)
+                .add("dataChangeCreatedBy", dataChangeCreatedBy)
+                .add("dataChangeCreatedTime", dataChangeCreatedTime)
+                .add("dataChangeLastModifiedBy", dataChangeLastModifiedBy)
+                .add("dataChangeLastModifiedTime", dataChangeLastModifiedTime);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseEntity that = (BaseEntity) o;
+        return Objects.equals(id, that.id) && Objects.equals(isDeleted, that.isDeleted) && Objects.equals(dataChangeCreatedBy, that.dataChangeCreatedBy) && Objects.equals(dataChangeCreatedTime, that.dataChangeCreatedTime) && Objects.equals(dataChangeLastModifiedBy, that.dataChangeLastModifiedBy) && Objects.equals(dataChangeLastModifiedTime, that.dataChangeLastModifiedTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, isDeleted, dataChangeCreatedBy, dataChangeCreatedTime, dataChangeLastModifiedBy, dataChangeLastModifiedTime);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Boolean getDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(Boolean deleted) {
+        isDeleted = deleted;
+    }
+
+    public String getDataChangeCreatedBy() {
+        return dataChangeCreatedBy;
+    }
+
+    public void setDataChangeCreatedBy(String dataChangeCreatedBy) {
+        this.dataChangeCreatedBy = dataChangeCreatedBy;
+    }
+
+    public Date getDataChangeCreatedTime() {
+        return dataChangeCreatedTime;
+    }
+
+    public void setDataChangeCreatedTime(Date dataChangeCreatedTime) {
+        this.dataChangeCreatedTime = dataChangeCreatedTime;
+    }
+
+    public String getDataChangeLastModifiedBy() {
+        return dataChangeLastModifiedBy;
+    }
+
+    public void setDataChangeLastModifiedBy(String dataChangeLastModifiedBy) {
+        this.dataChangeLastModifiedBy = dataChangeLastModifiedBy;
+    }
+
+    public Date getDataChangeLastModifiedTime() {
+        return dataChangeLastModifiedTime;
+    }
+
+    public void setDataChangeLastModifiedTime(Date dataChangeLastModifiedTime) {
+        this.dataChangeLastModifiedTime = dataChangeLastModifiedTime;
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/Consumer.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/Consumer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.entity;
+
+import java.util.Objects;
+
+/**
+ * @author wxq
+ * @see <a href="https://github.com/ctripcorp/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/Consumer.java">com/ctrip/framework/apollo/openapi/entity/Consumer</a>
+ */
+public class Consumer extends BaseEntity {
+
+    private String name;
+
+    private String appId;
+
+    private String orgId;
+
+    private String orgName;
+
+    private String ownerName;
+
+    private String ownerEmail;
+
+    @Override
+    public String toString() {
+        return toStringHelper().add("name", name).add("appId", appId)
+                .add("orgId", orgId)
+                .add("orgName", orgName)
+                .add("ownerName", ownerName)
+                .add("ownerEmail", ownerEmail).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        Consumer consumer = (Consumer) o;
+        return Objects.equals(name, consumer.name) && Objects.equals(appId, consumer.appId) && Objects.equals(orgId, consumer.orgId) && Objects.equals(orgName, consumer.orgName) && Objects.equals(ownerName, consumer.ownerName) && Objects.equals(ownerEmail, consumer.ownerEmail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name, appId, orgId, orgName, ownerName, ownerEmail);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    public String getOrgName() {
+        return orgName;
+    }
+
+    public void setOrgName(String orgName) {
+        this.orgName = orgName;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public String getOwnerEmail() {
+        return ownerEmail;
+    }
+
+    public void setOwnerEmail(String ownerEmail) {
+        this.ownerEmail = ownerEmail;
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/ConsumerRole.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/ConsumerRole.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.entity;
+
+import java.util.Objects;
+
+/**
+ * @author wxq
+ * @see <a href="https://github.com/ctripcorp/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerRole.java">com/ctrip/framework/apollo/openapi/entity/ConsumerRole</a>
+ */
+public class ConsumerRole extends BaseEntity {
+
+    private Long consumerId;
+
+    private Long roleId;
+
+    @Override
+    public String toString() {
+        return toStringHelper().add("consumerId", consumerId).add("roleId", roleId).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ConsumerRole that = (ConsumerRole) o;
+        return Objects.equals(consumerId, that.consumerId) && Objects.equals(roleId, that.roleId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), consumerId, roleId);
+    }
+
+    public Long getConsumerId() {
+        return consumerId;
+    }
+
+    public void setConsumerId(Long consumerId) {
+        this.consumerId = consumerId;
+    }
+
+    public Long getRoleId() {
+        return roleId;
+    }
+
+    public void setRoleId(Long roleId) {
+        this.roleId = roleId;
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/ConsumerToken.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/ConsumerToken.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.entity;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author wxq
+ * @see <a href="https://github.com/ctripcorp/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity/ConsumerToken.java">com/ctrip/framework/apollo/openapi/entity/ConsumerToken</a>
+ */
+public class ConsumerToken extends BaseEntity {
+
+    private Long consumerId;
+
+    private String token;
+
+    private Date expires;
+
+    @Override
+    public String toString() {
+        return toStringHelper().add("consumerId", consumerId).add("token", token)
+                .add("expires", expires).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ConsumerToken that = (ConsumerToken) o;
+        return Objects.equals(consumerId, that.consumerId) && Objects.equals(token, that.token) && Objects.equals(expires, that.expires);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), consumerId, token, expires);
+    }
+
+    public Long getConsumerId() {
+        return consumerId;
+    }
+
+    public void setConsumerId(Long consumerId) {
+        this.consumerId = consumerId;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Date getExpires() {
+        return expires;
+    }
+
+    public void setExpires(Date expires) {
+        this.expires = expires;
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/package-info.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/entity/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * simulate with apollo portal's source code.
+ *
+ * @see <a href="https://github.com/ctripcorp/apollo/tree/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/openapi/entity">com/ctrip/framework/apollo/openapi/entity</a>
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.entity;

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/ApolloPortalService.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/ApolloPortalService.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.service;
+
+import com.alibaba.csp.sentinel.dashboard.apollo.config.SentinelApolloOpenApiProperties;
+import com.alibaba.csp.sentinel.dashboard.apollo.entity.ConsumerRole;
+import com.alibaba.fastjson.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Call apollo portal.
+ *
+ * @author wxq
+ * @see <a href="https://github.com/ctripcorp/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConsumerController.java">ConsumerController.java</a> for HTTP API information.
+ */
+@Service
+public class ApolloPortalService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApolloPortalService.class);
+
+    private final SentinelApolloOpenApiProperties sentinelApolloOpenApiProperties;
+
+    private final URI authorizedURI;
+
+    public ApolloPortalService(SentinelApolloOpenApiProperties sentinelApolloOpenApiProperties) {
+        this.sentinelApolloOpenApiProperties = sentinelApolloOpenApiProperties;
+        final String portalUrl = sentinelApolloOpenApiProperties.getPortalUrl();
+        final String token = sentinelApolloOpenApiProperties.getToken();
+        final String authorizedPath = String.format("consumers/%s/assign-role?type=AppRole", token);
+        this.authorizedURI = URI.create(portalUrl).resolve(authorizedPath);
+    }
+
+    private static HttpHeaders buildHttpHeaders(String jsessionid) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON_UTF8);
+
+        // cookie
+        httpHeaders.add(HttpHeaders.COOKIE, "JSESSIONID=" + jsessionid);
+
+        return httpHeaders;
+    }
+
+    public ResponseEntity<ConsumerRole[]> assignAppRoleToConsumer(String jsessionid, String appId) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders httpHeaders = buildHttpHeaders(jsessionid);
+
+        final String jsonString = JSONObject.toJSONString(Collections.singletonMap("appId", appId));
+        HttpEntity<String> httpEntity = new HttpEntity<>(jsonString, httpHeaders);
+
+        ResponseEntity<ConsumerRole[]> responseEntity = restTemplate.postForEntity(authorizedURI, httpEntity, ConsumerRole[].class);
+
+        return responseEntity;
+    }
+
+    /**
+     * Use admin permission to call apollo portal, authorize managed app id, type is app.
+     * @param jsessionid JESSIONID in Cookie
+     * @param appIds app id in apollo
+     * @return authorization's result, key is app id, value is true if success, false if failed.
+     */
+    public Map<String, ResponseEntity<ConsumerRole[]>> assignAppRoleToConsumer(final String jsessionid, Set<String> appIds) {
+        Function<String, ResponseEntity<ConsumerRole[]>> function = appId -> {
+//            try {
+                return assignAppRoleToConsumer(jsessionid, appId);
+//            } catch (RuntimeException e) {
+//                return false;
+//            }
+        };
+        Map<String, ResponseEntity<ConsumerRole[]>> result = appIds.parallelStream().collect(Collectors.toMap(Function.identity(), function));
+        return result;
+    }
+
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelApolloService.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelApolloService.java
@@ -16,7 +16,9 @@
 package com.alibaba.csp.sentinel.dashboard.apollo.service;
 
 import com.alibaba.cloud.sentinel.datasource.RuleType;
+import com.alibaba.csp.sentinel.dashboard.apollo.entity.ConsumerRole;
 import com.alibaba.csp.sentinel.slots.block.Rule;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 import java.util.Map;
@@ -44,6 +46,8 @@ public interface SentinelApolloService {
     Set<String> autoRegistryProjectsSkipFailed();
 
     CompletableFuture<Set<String>> autoRegistryProjectsSkipFailedAsync();
+
+    Map<String, Boolean> autoRegistryHeartbeatProjects(String jsessionid);
 
     CompletableFuture<Void> setRulesAsync(String projectName, RuleType ruleType, List<? extends Rule> rules);
 

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
@@ -54,12 +54,15 @@
             <!-- 导出配置文件 -->
             <div class="container-fluid">
                 <div class="row-fluid">
+                    <h2 class="text-center">
+                        导出规则
+                    </h2>
                     <div class="span12">
-                        <h2 class="text-center">
-                            导出规则
-                        </h2>
+                        <h3 class="text-center">
+                            简介
+                        </h3>
                         <p>
-                            导出所有应用的配置，格式是.zip
+                            导出应用的配置，格式是.zip
                         </p>
                         <p>
                             .zip文件里的目录结构如下
@@ -71,10 +74,8 @@
 |   |-- SYSTEM.json
 |   |-- AUTHORITY.json</pre>
                         </p>
-                        <div class="container-fluid">
-                            <div class="row-fluid">
-                                <div class="span12">
-                                    <table class="table table-bordered table-hover">
+
+                        <table class="table table-bordered table-hover">
                                         <thead>
                                         <tr>
                                             <th>
@@ -128,9 +129,7 @@
                                         </tr>
                                         </tbody>
                                     </table>
-                                </div>
-                            </div>
-                        </div>
+
                         <p>
                             应用的xxx规则保存在xxx.json文件中
                         </p>
@@ -140,14 +139,26 @@
                         <p>
                             例如应用名是order，没有DEGRADE规则，那么在order的文件夹下，不会产生DEGRADE.json文件
                         </p>
-                        <a href="config/export/all" target="_blank">
-                            <button class="btn btn-block btn-primary">
-                                导出所有应用的所有规则
-                            </button>
-                        </a>
-                        <br/>
+
+                    </div>
+                    <div class="span12">
+                        <h3 class="text-center">
+                            导出单个应用的所有规则
+                        </h3>
                         <p>
-                            控制台没有显示应用，但是只想导出单个应用的规则，可以在下方填入应用名，然后点击按钮
+                            控制台没有显示应用，但是只想导出单个应用的规则，
+                        </p>
+                        <p>
+                            可以在下方填入应用名，然后点击按钮，
+                        </p>
+                        <p>
+                            注意会导出这个应用的所有规则
+                        </p>
+                        <p>
+                            如果在左侧的<strong>侧边栏</strong>中，可以找到应用，
+                            推荐<strong>不使用这里的按钮</strong>，
+                            可以在侧边栏点开应用的<strong>实时监控</strong>或者<strong>簇点链路</strong>，
+                            然后在页面中点击导出xxx的所有规则
                         </p>
                         <form class="form-horizontal" action="config/export" method="GET"
                               enctype="application/x-www-form-urlencoded">
@@ -158,20 +169,39 @@
                             </div>
                             <div class="control-group">
                                 <div class="controls">
-                                    <button type="submit" class="btn btn-primary">导出应用的规则</button>
+                                    <button type="submit" class="btn btn-primary">导出应用的所有规则</button>
                                 </div>
                             </div>
                         </form>
+                    </div>
+                    <div class="span12">
+                        <h3 class="text-center">
+                            导出所有应用的所有规则
+                        </h3>
+                        <p>
+                            慎用，会一次性导出所有应用的所有规则，推荐在大规模迁移规则的时候使用，
+                        </p>
+                        <p>
+                            导出的.zip文件，有覆盖他人配置的风险，请谨慎操作
+                        </p>
+                        <a href="config/export/all" target="_blank">
+                            <button class="btn btn-block btn-primary">
+                                导出所有应用的所有规则
+                            </button>
+                        </a>
                     </div>
                 </div>
             </div>
 
             <div class="container-fluid">
                 <div class="row-fluid">
+                    <h2 class="text-center">
+                        应用基本操作
+                    </h2>
                     <div class="span12">
-                        <h2 class="text-center">
-                            应用基本操作
-                        </h2>
+                        <h3 class="text-center">
+                            查询
+                        </h3>
                         <table class="table table-bordered table-hover">
                             <thead>
                             <tr>
@@ -208,6 +238,25 @@
                                     获取目前在Apollo上有哪些项目（应用的app.id），无论是否接入控制台，都会显示
                                 </td>
                             </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="span12">
+                        <h3 class="text-center">
+                            注册
+                        </h3>
+                        <table class="table table-bordered table-hover">
+                            <thead>
+                            <tr>
+                                <th>
+                                    按钮
+                                </th>
+                                <th>
+                                    功能描述
+                                </th>
+                            </tr>
+                            </thead>
+                            <tbody>
                             <tr>
                                 <td>
                                     <a href="sentinel/apollo/auto/registry/projects/skip/failed/async" target="_blank">
@@ -221,6 +270,25 @@
                                     会自动跳过没有被赋权的项目，异步操作
                                 </td>
                             </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="span12">
+                        <h3 class="text-center">
+                            清理
+                        </h3>
+                        <table class="table table-bordered table-hover">
+                            <thead>
+                            <tr>
+                                <th>
+                                    按钮
+                                </th>
+                                <th>
+                                    功能描述
+                                </th>
+                            </tr>
+                            </thead>
+                            <tbody>
                             <tr>
                                 <td>
                                     <a href="sentinel/apollo/clear/registered/projects" target="_blank">

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
@@ -245,6 +245,42 @@
                         <h3 class="text-center">
                             注册
                         </h3>
+                        <p>
+                            注册应用到sentinel控制台，让sentinel控制台可以修改应用的规则
+                        </p>
+                        <p>
+                            注册 = Apollo开放平台授权被管理的AppId + Sentinel控制台存储应用
+                        </p>
+                        <h4>
+                            注册侧边栏的应用
+                        </h4>
+                        <p>
+                            自动注册左侧侧边栏中，还没有被注册到sentinel控制台的应用。
+                        </p>
+                        <p>
+                            如果应用还没有被赋权，那么会使用超级管理员权限，
+                            调用Apollo开放平台授权管理的接口，将其自动赋权。
+                        </p>
+                        <p>
+                            会返回需要注册的应用是否注册成功，如果没有新的应用需要注册，你会看不到任何应用名
+                        </p>
+                        <form class="form-horizontal" action="sentinel/apollo/auto/registry/heartbeat/projects" method="POST"
+                              enctype="multipart/form-data">
+                            <div class="control-group">
+                                <label class="form-label" for="inputText">JSESSIONID</label>
+                                <input class="form-control-file form-control-lg" id="inputText" type="text"
+                                       name="JSESSIONID"/>
+                                <p class="help-block">输入超级管理员用户apollo登录portal后，Cookie里的JSESSIONID</p>
+                            </div>
+                            <div class="control-group">
+                                <div class="controls">
+                                    <button type="submit" class="btn btn-primary">注册侧边栏的应用</button>
+                                </div>
+                            </div>
+                        </form>
+                        <h4>
+                            其它注册功能
+                        </h4>
                         <table class="table table-bordered table-hover">
                             <thead>
                             <tr>
@@ -266,8 +302,8 @@
                                     </a>
                                 </td>
                                 <td>
-                                    遍历所有在Apollo上的项目，然后将被赋权的项目，存储到控制台，
-                                    会自动跳过没有被赋权的项目，异步操作
+                                    遍历所有在Apollo上的项目，然后将被管理的AppId，存储到Sentinel控制台，
+                                    会自动跳过没有被管理的AppId，异步操作，Apollo的项目过多时，这个操作会耗时很长（1w个项目会耗时5分钟）
                                 </td>
                             </tr>
                             </tbody>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Use apollo `JSESSIONID` in portal's Cookie, to auto authrize managed app id, and registry them to sentinel dashboard.

Make the authorization of new project more easier.

### Describe how you did it

Put `JSESSIONID` in Cookie, and send HTTP POST to apollo portal.

The apollo portal's controller in https://github.com/ctripcorp/apollo/blob/master/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/controller/ConsumerController.java


HTTP URL

```
consumers/{token}/assign-role?type=AppRole
```

example

```
consumers/58bb334437c20e55b86329d4238cd5baf4d4d420/assign-role?type=AppRole
```

Request Body

```json
{"appId":"test"}
```

### Describe how to verify it

Test it manually.