### PR TITLE
feature: authorize project in apollo when import config from file in sentinel dashboard

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/controller/ProjectConfigController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/controller/ProjectConfigController.java
@@ -17,10 +17,11 @@ package com.alibaba.csp.sentinel.dashboard.apollo.controller;
 
 import com.alibaba.cloud.sentinel.datasource.RuleType;
 import com.alibaba.csp.sentinel.config.SentinelConfig;
+import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelProjectConfigService;
+import com.alibaba.csp.sentinel.dashboard.apollo.util.ConfigFileUtils;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
 import com.alibaba.csp.sentinel.dashboard.domain.Result;
-import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelProjectConfigService;
 import com.alibaba.csp.sentinel.slots.block.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,7 @@ public class ProjectConfigController {
             @RequestParam(required = false) RuleType ruleType,
             HttpServletRequest request, HttpServletResponse response
     ) throws IOException {
-        String filename = SentinelProjectConfigService.generateZipFilename();
+        String filename = ConfigFileUtils.generateZipFilename();
         // log who download the configs
         logger.info(
                 "Download configs, remote addr [{}], remote host [{}]. Filename is [{}], project name = [{}], rule type = [{}]",
@@ -86,7 +87,7 @@ public class ProjectConfigController {
     @GetMapping("/export/all")
     @AuthAction(AuthService.PrivilegeType.READ_RULE)
     public void export(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String filename = SentinelProjectConfigService.generateZipFilename();
+        String filename = ConfigFileUtils.generateZipFilename();
         // log who download the configs
         logger.info("Download configs, remote addr [{}], remote host [{}]. Filename is [{}]", request.getRemoteAddr(), request.getRemoteHost(), filename);
         // set downloaded filename

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelProjectConfigService.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelProjectConfigService.java
@@ -62,9 +62,7 @@ public class SentinelProjectConfigService {
         writeAsZipOutputStream(outputStream, projectName2rules);
     }
 
-    public Map<String, Map<RuleType, List<? extends Rule>>> importAllFrom(InputStream inputStream) throws IOException {
-        final Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules = readProjectName2Rules(inputStream);
-
+    public Map<String, Map<RuleType, List<? extends Rule>>> importAllFrom(Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules) {
         // registry projects
         logger.info("import {} projects config. project names = {}", projectName2rules.size(), projectName2rules.keySet());
         for (String projectName : projectName2rules.keySet()) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelProjectConfigService.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelProjectConfigService.java
@@ -16,35 +16,25 @@
 package com.alibaba.csp.sentinel.dashboard.apollo.service;
 
 import com.alibaba.cloud.sentinel.datasource.RuleType;
-import com.alibaba.csp.sentinel.dashboard.apollo.util.DataSourceConverterUtils;
 import com.alibaba.csp.sentinel.slots.block.Rule;
-import org.apache.commons.lang.time.DateFormatUtils;
-import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
-import static com.alibaba.csp.sentinel.dashboard.apollo.util.DataSourceConverterUtils.SERIALIZER;
+import static com.alibaba.csp.sentinel.dashboard.apollo.util.ConfigFileUtils.readProjectName2Rules;
+import static com.alibaba.csp.sentinel.dashboard.apollo.util.ConfigFileUtils.writeAsZipOutputStream;
 
 @Service
 public class SentinelProjectConfigService {
 
     private static final Logger logger = LoggerFactory.getLogger(SentinelProjectConfigService.class);
-
-    /**
-     * @see <a href="https://stackoverflow.com/questions/13846000/file-separators-of-path-name-of-zipentry">File separators of Path name of ZipEntry?</a>
-     */
-    private static final String FORWARD_SLASH = "/";
-
-    private static final String FILENAME_SUFFIX = ".json";
 
     private final SentinelApolloService sentinelApolloService;
 
@@ -52,77 +42,6 @@ public class SentinelProjectConfigService {
         this.sentinelApolloService = sentinelApolloService;
     }
 
-    static ZipEntry resolveZipEntry(String projectName, RuleType ruleType) {
-        return new ZipEntry(String.join(FORWARD_SLASH, projectName, ruleType.name() + FILENAME_SUFFIX));
-    }
-
-    /**
-     * @throws IllegalArgumentException if zipEntry is a directory
-     * @see #resolveZipEntry(String, RuleType)
-     */
-    static String getProjectName(ZipEntry zipEntry) {
-        Assert.isTrue(! zipEntry.isDirectory(), "zip entry" + zipEntry + " should not be a directory");
-        File file = new File(zipEntry.getName());
-        return file.getParent();
-    }
-
-    /**
-     * @see #resolveZipEntry(String, RuleType)
-     */
-    static RuleType getRuleType(ZipEntry zipEntry) {
-        Assert.isTrue(! zipEntry.isDirectory(), "zip entry" + zipEntry + " should not be a directory");
-        String filename = new File(zipEntry.getName()).getName();
-        Assert.isTrue(filename.endsWith(FILENAME_SUFFIX), "filename '" + filename + "' should ends with " + FILENAME_SUFFIX);
-
-        // delete suffix
-        String ruleTypeName = filename.substring(0, filename.length() - FILENAME_SUFFIX.length());
-        return RuleType.valueOf(ruleTypeName);
-    }
-
-    private static void write2ZipOutputStream(ZipOutputStream zipOutputStream, String projectName, RuleType ruleType, List<? extends Rule> rules) throws IOException {
-        ZipEntry zipEntry = resolveZipEntry(projectName, ruleType);
-
-        try {
-            zipOutputStream.putNextEntry(zipEntry);
-            String jsonContent = SERIALIZER.convert(rules);
-            zipOutputStream.write(jsonContent.getBytes(StandardCharsets.UTF_8));
-            zipOutputStream.closeEntry();
-        } catch (IOException e) {
-            String message = "config export failed. project name = " + projectName;
-            logger.error(message, projectName);
-            throw new IOException(message, e);
-        }
-    }
-
-    private static void write2ZipOutputStream(ZipOutputStream zipOutputStream, String projectName, Map<RuleType, List<? extends Rule>> ruleTypeListMap)
-            throws IOException {
-        for (Map.Entry<RuleType, List<? extends Rule>> entry : ruleTypeListMap.entrySet()) {
-            RuleType ruleType = entry.getKey();
-            List<? extends Rule> rules = entry.getValue();
-            if (rules.size() > 0) {
-                write2ZipOutputStream(zipOutputStream, projectName, ruleType, rules);
-            }
-        }
-    }
-
-    private static void writeAsZipOutputStream(OutputStream outputStream, Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules)
-            throws IOException {
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
-            for (Map.Entry<String, Map<RuleType, List<? extends Rule>>> entry : projectName2rules.entrySet()) {
-                String projectName = entry.getKey();
-                Map<RuleType, List<? extends Rule>> ruleTypeListMap = entry.getValue();
-                if (ruleTypeListMap.size() > 0) {
-                    write2ZipOutputStream(zipOutputStream, projectName, ruleTypeListMap);
-                }
-            }
-        }
-    }
-
-    public static String generateZipFilename() {
-        // must contain the information of time
-        final String zipFilename = "sentinel_config_export_" + DateFormatUtils.format(new Date(), "yyyy_MMdd_HH_mm_ss") + ".zip";
-        return zipFilename;
-    }
 
     public void exportAllToZip(OutputStream outputStream) throws IOException {
         Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules = this.sentinelApolloService.getRules();
@@ -143,44 +62,8 @@ public class SentinelProjectConfigService {
         writeAsZipOutputStream(outputStream, projectName2rules);
     }
 
-    private static List<? extends Rule> readRules(InputStream inputStream, RuleType ruleType) throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        IOUtils.copy(inputStream, byteArrayOutputStream);
-        byte[] bytes = byteArrayOutputStream.toByteArray();
-        return DataSourceConverterUtils.deserialize(bytes, ruleType);
-    }
-
-    private static Map<String, Map<RuleType, List<? extends Rule>>> readFromZipInputStream(ZipInputStream zipInputStream) throws IOException {
-        Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules = new HashMap<>();
-        for (
-                ZipEntry zipEntry = zipInputStream.getNextEntry();
-                null != zipEntry;
-                zipEntry = zipInputStream.getNextEntry()
-        ) {
-            if (!zipEntry.isDirectory()) {
-                String projectName = getProjectName(zipEntry);
-                if (!projectName2rules.containsKey(projectName)) {
-                    projectName2rules.put(projectName, new HashMap<>());
-                }
-
-                RuleType ruleType = getRuleType(zipEntry);
-                // read content
-                List<? extends Rule> rules = readRules(zipInputStream, ruleType);
-                // add rules
-                projectName2rules.get(projectName).put(ruleType, rules);
-            }
-
-            zipInputStream.closeEntry();
-        }
-
-        return projectName2rules;
-    }
-
     public Map<String, Map<RuleType, List<? extends Rule>>> importAllFrom(InputStream inputStream) throws IOException {
-        final Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules;
-        try (ZipInputStream zipInputStream = new ZipInputStream(inputStream)) {
-            projectName2rules = readFromZipInputStream(zipInputStream);
-        }
+        final Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules = readProjectName2Rules(inputStream);
 
         // registry projects
         logger.info("import {} projects config. project names = {}", projectName2rules.size(), projectName2rules.keySet());

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/impl/DefaultSentinelApolloServiceImpl.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/impl/DefaultSentinelApolloServiceImpl.java
@@ -294,15 +294,7 @@ public class DefaultSentinelApolloServiceImpl implements SentinelApolloService {
         logger.info("those {} projects have not registry yet. {}", projectNamesCannotRegistry.size(), projectNamesCannotRegistry);
 
         // authorize them
-        Map<String, ResponseEntity<ConsumerRole[]>> assignResult = this.apolloPortalService.assignAppRoleToConsumer(jsessionid, projectNamesCannotRegistry);
-
-        final Map<String, Boolean> registryResult = new HashMap<>();
-        for (Map.Entry<String, ResponseEntity<ConsumerRole[]>> entry : assignResult.entrySet()) {
-            String projectName = entry.getKey();
-            ResponseEntity<ConsumerRole[]> responseEntity = entry.getValue();
-            logger.debug("registry project [{}] ResponseEntity [{}] ", projectName, responseEntity);
-            registryResult.put(projectName, responseEntity.getStatusCode().is2xxSuccessful());
-        }
+        Map<String, Boolean> registryResult = this.apolloPortalService.assignAppRoleToSentinelDashboard(jsessionid, projectNamesCannotRegistry);
         return registryResult;
     }
 

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtils.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtils.java
@@ -16,7 +16,6 @@
 package com.alibaba.csp.sentinel.dashboard.apollo.util;
 
 import com.alibaba.cloud.sentinel.datasource.RuleType;
-import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelApolloService;
 import com.alibaba.csp.sentinel.slots.block.Rule;
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
@@ -34,8 +33,11 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
-import static com.alibaba.csp.sentinel.dashboard.apollo.util.DataSourceConverterUtils.SERIALIZER;
-
+/**
+ * Save {@link Rule} to .zip file, or read {@link Rule} from .zip file.
+ *
+ * @author wxq
+ */
 public class ConfigFileUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigFileUtils.class);
@@ -79,7 +81,7 @@ public class ConfigFileUtils {
 
         try {
             zipOutputStream.putNextEntry(zipEntry);
-            String jsonContent = SERIALIZER.convert(rules);
+            String jsonContent = DataSourceConverterUtils.serializeToString(rules);
             zipOutputStream.write(jsonContent.getBytes(StandardCharsets.UTF_8));
             zipOutputStream.closeEntry();
         } catch (IOException e) {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtils.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtils.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.util;
+
+import com.alibaba.cloud.sentinel.datasource.RuleType;
+import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelApolloService;
+import com.alibaba.csp.sentinel.slots.block.Rule;
+import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.tomcat.util.http.fileupload.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static com.alibaba.csp.sentinel.dashboard.apollo.util.DataSourceConverterUtils.SERIALIZER;
+
+public class ConfigFileUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigFileUtils.class);
+
+    /**
+     * @see <a href="https://stackoverflow.com/questions/13846000/file-separators-of-path-name-of-zipentry">File separators of Path name of ZipEntry?</a>
+     */
+    private static final String FORWARD_SLASH = "/";
+
+    private static final String FILENAME_SUFFIX = ".json";
+
+    static ZipEntry resolveZipEntry(String projectName, RuleType ruleType) {
+        return new ZipEntry(String.join(FORWARD_SLASH, projectName, ruleType.name() + FILENAME_SUFFIX));
+    }
+
+    /**
+     * @throws IllegalArgumentException if zipEntry is a directory
+     * @see #resolveZipEntry(String, RuleType)
+     */
+    static String getProjectName(ZipEntry zipEntry) {
+        Assert.isTrue(!zipEntry.isDirectory(), "zip entry" + zipEntry + " should not be a directory");
+        File file = new File(zipEntry.getName());
+        return file.getParent();
+    }
+
+    /**
+     * @see #resolveZipEntry(String, RuleType)
+     */
+    static RuleType getRuleType(ZipEntry zipEntry) {
+        Assert.isTrue(!zipEntry.isDirectory(), "zip entry" + zipEntry + " should not be a directory");
+        String filename = new File(zipEntry.getName()).getName();
+        Assert.isTrue(filename.endsWith(FILENAME_SUFFIX), "filename '" + filename + "' should ends with " + FILENAME_SUFFIX);
+
+        // delete suffix
+        String ruleTypeName = filename.substring(0, filename.length() - FILENAME_SUFFIX.length());
+        return RuleType.valueOf(ruleTypeName);
+    }
+
+    private static void write2ZipOutputStream(ZipOutputStream zipOutputStream, String projectName, RuleType ruleType, List<? extends Rule> rules) throws IOException {
+        ZipEntry zipEntry = resolveZipEntry(projectName, ruleType);
+
+        try {
+            zipOutputStream.putNextEntry(zipEntry);
+            String jsonContent = SERIALIZER.convert(rules);
+            zipOutputStream.write(jsonContent.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        } catch (IOException e) {
+            String message = "config export failed. project name = " + projectName;
+            logger.error(message, projectName);
+            throw new IOException(message, e);
+        }
+    }
+
+    private static void write2ZipOutputStream(ZipOutputStream zipOutputStream, String projectName, Map<RuleType, List<? extends Rule>> ruleTypeListMap)
+            throws IOException {
+        for (Map.Entry<RuleType, List<? extends Rule>> entry : ruleTypeListMap.entrySet()) {
+            RuleType ruleType = entry.getKey();
+            List<? extends Rule> rules = entry.getValue();
+            if (rules.size() > 0) {
+                write2ZipOutputStream(zipOutputStream, projectName, ruleType, rules);
+            }
+        }
+    }
+
+    public static void writeAsZipOutputStream(OutputStream outputStream, Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules)
+            throws IOException {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            for (Map.Entry<String, Map<RuleType, List<? extends Rule>>> entry : projectName2rules.entrySet()) {
+                String projectName = entry.getKey();
+                Map<RuleType, List<? extends Rule>> ruleTypeListMap = entry.getValue();
+                if (ruleTypeListMap.size() > 0) {
+                    write2ZipOutputStream(zipOutputStream, projectName, ruleTypeListMap);
+                }
+            }
+        }
+    }
+
+    public static String generateZipFilename() {
+        // must contain the information of time
+        final String zipFilename = "sentinel_config_export_" + DateFormatUtils.format(new Date(), "yyyy_MMdd_HH_mm_ss") + ".zip";
+        return zipFilename;
+    }
+
+    private static Map<String, Map<RuleType, List<? extends Rule>>> readFromZipInputStream(ZipInputStream zipInputStream) throws IOException {
+        Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules = new HashMap<>();
+        for (
+                ZipEntry zipEntry = zipInputStream.getNextEntry();
+                null != zipEntry;
+                zipEntry = zipInputStream.getNextEntry()
+        ) {
+            if (!zipEntry.isDirectory()) {
+                String projectName = getProjectName(zipEntry);
+                if (!projectName2rules.containsKey(projectName)) {
+                    projectName2rules.put(projectName, new HashMap<>());
+                }
+
+                RuleType ruleType = getRuleType(zipEntry);
+                // read content
+                List<? extends Rule> rules = readRules(zipInputStream, ruleType);
+                // add rules
+                projectName2rules.get(projectName).put(ruleType, rules);
+            }
+
+            zipInputStream.closeEntry();
+        }
+
+        return projectName2rules;
+    }
+
+    private static List<? extends Rule> readRules(InputStream inputStream, RuleType ruleType) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        IOUtils.copy(inputStream, byteArrayOutputStream);
+        byte[] bytes = byteArrayOutputStream.toByteArray();
+        return DataSourceConverterUtils.deserialize(bytes, ruleType);
+    }
+
+    public static Map<String, Map<RuleType, List<? extends Rule>>> readProjectName2Rules(InputStream inputStream) throws IOException {
+        final Map<String, Map<RuleType, List<? extends Rule>>> projectName2rules;
+        try (ZipInputStream zipInputStream = new ZipInputStream(inputStream)) {
+            projectName2rules = readFromZipInputStream(zipInputStream);
+        }
+        return projectName2rules;
+    }
+}

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/DataSourceConverterUtils.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/DataSourceConverterUtils.java
@@ -25,26 +25,28 @@ import java.util.List;
 import java.util.function.BiFunction;
 
 /**
+ * convert {@link Rule} to json string or vice versa.
  *
+ * @author wxq
  */
-public interface DataSourceConverterUtils {
+public class DataSourceConverterUtils {
 
-    Converter<List<? extends Rule>, String> SERIALIZER = rule -> JSON.toJSONString(rule, true);
+    private static final Converter<List<? extends Rule>, String> SERIALIZER = rule -> JSON.toJSONString(rule, true);
 
-    BiFunction<String, RuleType, List<? extends Rule>> DESERIALIZER = (json, ruleType) -> {
+    private static final BiFunction<String, RuleType, List<? extends Rule>> DESERIALIZER = (json, ruleType) -> {
         Class<? extends Rule> ruleClazz = ruleType.getClazz();
         return JSON.parseArray(json, ruleClazz);
     };
 
-    static String serializeToString(List<? extends Rule> rules) {
+    public static String serializeToString(List<? extends Rule> rules) {
         return SERIALIZER.convert(rules);
     }
 
-    static List<? extends Rule> deserialize(String content, RuleType ruleType) {
+    public static List<? extends Rule> deserialize(String content, RuleType ruleType) {
         return DESERIALIZER.apply(content, ruleType);
     }
 
-    static List<? extends Rule> deserialize(byte[] bytes, RuleType ruleType) {
+    public static List<? extends Rule> deserialize(byte[] bytes, RuleType ruleType) {
         String content = new String(bytes, StandardCharsets.UTF_8);
         return DESERIALIZER.apply(content, ruleType);
     }

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
@@ -12,6 +12,12 @@
                         <h2 class="text-center">
                             导入规则
                         </h2>
+                        <p>
+                            使用这个功能之前，你需要在其它环境的Sentinel控制台导出规则
+                        </p>
+                        <p>
+                            还要确保应用（项目）在Apollo上已经被创建
+                        </p>
                         <form class="form-horizontal" action="config/import/all" method="POST"
                               enctype="multipart/form-data">
                             <div class="control-group">
@@ -21,11 +27,22 @@
                                 <p class="help-block">请选择你在另一个环境导出的.zip文件</p>
                             </div>
                             <div class="control-group">
+                                <label class="form-label" for="inputText">JSESSIONID</label>
+                                <input class="form-control-file form-control-lg" id="inputText" type="text"
+                                       name="JSESSIONID"/>
+                                <p class="help-block">可选输入</p>
+                                <p class="help-block">超级管理员用户apollo登录portal后，Cookie里的JSESSIONID</p>
+                                <p class="help-block">输入后，会自动注册应用到Sentinel控制台</p>
+                            </div>
+                            <div class="control-group">
                                 <div class="controls">
                                     <button type="submit" class="btn btn-primary">导入</button>
                                 </div>
                             </div>
                         </form>
+                        <p>
+                            以下是导入规则的细节
+                        </p>
                         <p>
                             以json文件作为最小单位，来导入规则，
                             如果.zip中有文件<strong>应用名/xxx.json</strong>，

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtilsTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtilsTest.java
@@ -1,32 +1,32 @@
-package com.alibaba.csp.sentinel.dashboard.apollo.service;
+package com.alibaba.csp.sentinel.dashboard.apollo.util;
 
 import com.alibaba.cloud.sentinel.datasource.RuleType;
 import junit.framework.TestCase;
 
 import java.util.zip.ZipEntry;
 
-public class SentinelProjectConfigServiceTest extends TestCase {
+public class ConfigFileUtilsTest extends TestCase {
 
     public void testResolveZipEntry() {
-        ZipEntry zipEntry = SentinelProjectConfigService.resolveZipEntry("app", RuleType.SYSTEM);
+        ZipEntry zipEntry = ConfigFileUtils.resolveZipEntry("app", RuleType.SYSTEM);
         assertTrue(zipEntry.getName().startsWith("app"));
         assertTrue(zipEntry.getName().contains(RuleType.SYSTEM.name()));
         assertFalse(zipEntry.getName().contains(RuleType.SYSTEM.getName()));
 
-        ZipEntry zipEntry1 = SentinelProjectConfigService.resolveZipEntry("app1", RuleType.PARAM_FLOW);
+        ZipEntry zipEntry1 = ConfigFileUtils.resolveZipEntry("app1", RuleType.PARAM_FLOW);
         assertTrue(zipEntry1.getName().contains(RuleType.PARAM_FLOW.name()));
         assertFalse(zipEntry1.getName().contains(RuleType.PARAM_FLOW.getName()));
     }
 
     public void testGetProjectName() {
-        ZipEntry zipEntry = SentinelProjectConfigService.resolveZipEntry("app", RuleType.FLOW);
-        String projectName = SentinelProjectConfigService.getProjectName(zipEntry);
+        ZipEntry zipEntry = ConfigFileUtils.resolveZipEntry("app", RuleType.FLOW);
+        String projectName = ConfigFileUtils.getProjectName(zipEntry);
         assertEquals("app", projectName);
     }
 
     public void testGetRuleType() {
-        ZipEntry zipEntry = SentinelProjectConfigService.resolveZipEntry("app", RuleType.AUTHORITY);
-        RuleType ruleType = SentinelProjectConfigService.getRuleType(zipEntry);
+        ZipEntry zipEntry = ConfigFileUtils.resolveZipEntry("app", RuleType.AUTHORITY);
+        RuleType ruleType = ConfigFileUtils.getRuleType(zipEntry);
         assertEquals(ruleType, RuleType.AUTHORITY);
     }
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Authorize project in apollo when import config from file in sentinel dashboard.

Make new projects authorization and import config more easier.

### Describe how you did it

When import config from file, if user pass parameter `JSESSIONID`, sentinel dashboard will call apollo portal to let it self can manage project's config in apollo.

### Describe how to verify it

Test it manually.