### PR TITLE
feat(dashboard): registry multiple projects base on user's input text

### DIFF
--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/controller/ProjectConfigController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/controller/ProjectConfigController.java
@@ -22,6 +22,7 @@ import com.alibaba.csp.sentinel.dashboard.apollo.exception.ProjectsNotExistExcep
 import com.alibaba.csp.sentinel.dashboard.apollo.service.ApolloPortalService;
 import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelProjectConfigService;
 import com.alibaba.csp.sentinel.dashboard.apollo.util.ConfigFileUtils;
+import com.alibaba.csp.sentinel.dashboard.apollo.util.ProjectNameUtils;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
 import com.alibaba.csp.sentinel.dashboard.domain.Result;
@@ -165,13 +166,7 @@ public class ProjectConfigController {
             @RequestPart String multipleProjectNamesTextarea,
             HttpServletRequest request, HttpServletResponse response
     ) throws IOException {
-        String[] lines = multipleProjectNamesTextarea.split("\\R+");
-        Set<String> projectNames = Arrays.stream(lines)
-                // trim every lines
-                .map(String::trim)
-                // skip blank lines
-                .filter(StringUtils::hasText)
-                .collect(Collectors.toSet());
+        Set<String> projectNames = ProjectNameUtils.getEffectiveProjectNames(multipleProjectNamesTextarea);
 
         this.check(projectNames);
 

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/controller/SentinelApolloController.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/controller/SentinelApolloController.java
@@ -17,6 +17,7 @@ package com.alibaba.csp.sentinel.dashboard.apollo.controller;
 
 import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelApolloService;
 import com.alibaba.csp.sentinel.dashboard.apollo.service.SentinelDashboardService;
+import com.alibaba.csp.sentinel.dashboard.apollo.util.ProjectNameUtils;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthAction;
 import com.alibaba.csp.sentinel.dashboard.auth.AuthService;
 import com.alibaba.csp.sentinel.dashboard.domain.Result;
@@ -25,10 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -127,7 +125,7 @@ public class SentinelApolloController {
                     ;
         } else {
             // exist failed
-            String message = String.format("总共有%d个需要注册的应用，有%d个注册成功，%d个注册失败", totalCount, successCount, failedCount);
+            String message = String.format("总共有%d个需要注册的应用，有%d个注册成功，%d个注册失败，请检查应用（项目）在Apollo上是否存在，以及JSESSIONID填写是否正确", totalCount, successCount, failedCount);
             return Result.<Map<String, Set<String>>>ofFail(-1, message).setData(resultData);
         }
     }
@@ -136,6 +134,17 @@ public class SentinelApolloController {
     @AuthAction(AuthService.PrivilegeType.ALL)
     public Result<Map<String, Set<String>>> autoRegistryProjectsInSidebar(@RequestPart("JSESSIONID") String jsessionid) {
         Map<String, Boolean> registryResult = this.sentinelApolloService.autoRegistryProjectsInSidebar(jsessionid);
+        return toResult(registryResult);
+    }
+
+    @PostMapping(value = "/auto/registry/multiple/projects", produces = MediaType.APPLICATION_JSON_VALUE)
+    @AuthAction(AuthService.PrivilegeType.ALL)
+    public Result<Map<String, Set<String>>> autoRegistryMultipleProjects(
+            @RequestPart("JSESSIONID") String jsessionid,
+            @RequestPart String multipleProjectNamesTextarea
+    ) {
+        Set<String> projectNames = ProjectNameUtils.getEffectiveProjectNames(multipleProjectNamesTextarea);
+        Map<String, Boolean> registryResult = this.sentinelApolloService.autoRegistryMultipleProjects(jsessionid, projectNames);
         return toResult(registryResult);
     }
 

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelApolloService.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/SentinelApolloService.java
@@ -94,6 +94,14 @@ public interface SentinelApolloService {
      */
     Map<String, Boolean> autoRegistryProjectsInSidebar(String jsessionid);
 
+    /**
+     * Registry projects to sentinel dashboard.
+     *
+     * @param jsessionid JSESSIONID in Cookie
+     * @return key is project name, value is it registry successful or not
+     */
+    Map<String, Boolean> autoRegistryMultipleProjects(String jsessionid, Set<String> projectNames);
+
     CompletableFuture<Void> setRulesAsync(String projectName, RuleType ruleType, List<? extends Rule> rules);
 
     boolean setRules(String projectName, RuleType ruleType, List<? extends Rule> rules);

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/impl/DefaultSentinelApolloServiceImpl.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/service/impl/DefaultSentinelApolloServiceImpl.java
@@ -288,7 +288,8 @@ public class DefaultSentinelApolloServiceImpl implements SentinelApolloService {
         return CompletableFuture.supplyAsync(this::autoRegistryProjectsSkipFailed);
     }
 
-    private Map<String, Boolean> autoRegistryMultipleProjects(String jsessionid, Set<String> projectNames) {
+    @Override
+    public Map<String, Boolean> autoRegistryMultipleProjects(String jsessionid, Set<String> projectNames) {
 
         Predicate<String> isCannotRegistry = projectName -> {
             try {

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ProjectNameUtils.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ProjectNameUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.util;
+
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author wxq
+ */
+public class ProjectNameUtils {
+
+    /**
+     * Get multiple project names from a text.
+     * <p>
+     * Skip empty lines and trim every line.
+     *
+     * @param multipleProjectNamesTextarea text
+     * @return multiple project names
+     */
+    public static Set<String> getEffectiveProjectNames(String multipleProjectNamesTextarea) {
+        String[] lines = multipleProjectNamesTextarea.split("\\R+");
+        Set<String> projectNames = Arrays.stream(lines)
+                // trim every lines
+                .map(String::trim)
+                // skip blank lines
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+        return projectNames;
+    }
+
+}

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
@@ -343,6 +343,39 @@
 
         <div class="col-md-12">
             <h3>
+                注册多个应用
+            </h3>
+            <p>
+                从输入的应用列表中，自动注册还没有被注册到sentinel控制台的应用。
+            </p>
+            <p>
+                如果应用还没有被赋权，那么会使用超级管理员权限，
+                调用Apollo开放平台授权管理的接口，将其自动赋权。
+            </p>
+            <p>
+                会返回需要注册的应用是否注册成功，如果没有新的应用需要注册，你会看不到任何应用名
+            </p>
+            <form class="form-horizontal" action="sentinel/apollo/auto/registry/multiple/projects" method="POST" enctype="multipart/form-data">
+                <div class="control-group">
+                    <label class="form-label" for="inputText">JSESSIONID</label>
+                    <input class="form-control-file form-control-lg" id="inputText" type="text"
+                           name="JSESSIONID"/>
+                    <p class="help-block">输入超级管理员用户apollo登录portal后，Cookie里的JSESSIONID</p>
+                </div>
+                <div class="control-group">
+                    <textarea class="form-control" name="multipleProjectNamesTextarea" rows="5"></textarea>
+                    <p class="help-block">填入多个应用名，每个占一行，请勿输入空格，tab等字符</p>
+                </div>
+                <div class="control-group">
+                    <div class="controls">
+                        <button type="submit" class="btn btn-primary">注册多个应用</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        <div class="col-md-12">
+            <h3>
                 其它注册功能
             </h3>
             <table class="table table-bordered table-hover">

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtilsTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ConfigFileUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.csp.sentinel.dashboard.apollo.util;
 
 import com.alibaba.cloud.sentinel.datasource.RuleType;
@@ -5,6 +20,9 @@ import junit.framework.TestCase;
 
 import java.util.zip.ZipEntry;
 
+/**
+ * @author wxq
+ */
 public class ConfigFileUtilsTest extends TestCase {
 
     public void testResolveZipEntry() {

--- a/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ProjectNameUtilsTest.java
+++ b/sentinel-dashboard/src/test/java/com/alibaba/csp/sentinel/dashboard/apollo/util/ProjectNameUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.util;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author wxq
+ */
+public class ProjectNameUtilsTest {
+
+    @Test
+    public void getEffectiveProjectNames() {
+
+        // empty
+        assertEquals(Collections.EMPTY_SET, ProjectNameUtils.getEffectiveProjectNames("  "));
+        assertEquals(Collections.EMPTY_SET, ProjectNameUtils.getEffectiveProjectNames("\n \r\n  "));
+        assertEquals(Collections.EMPTY_SET, ProjectNameUtils.getEffectiveProjectNames(" \t "));
+        assertEquals(Collections.EMPTY_SET, ProjectNameUtils.getEffectiveProjectNames(" \n \b \t "));
+
+        // 1 element
+        assertEquals(Collections.singleton("a"), ProjectNameUtils.getEffectiveProjectNames("a"));
+        assertEquals(Collections.singleton("a b"), ProjectNameUtils.getEffectiveProjectNames("a b "));
+        assertEquals(Collections.singleton("abcd234"), ProjectNameUtils.getEffectiveProjectNames("abcd234"));
+        assertEquals(Collections.singleton("1"), ProjectNameUtils.getEffectiveProjectNames(" \t1\n"));
+        assertEquals(Collections.singleton("2"), ProjectNameUtils.getEffectiveProjectNames("\n\r\n2\n"));
+
+        // 2 elements
+        assertEquals(2, ProjectNameUtils.getEffectiveProjectNames("a\nb").size());
+        assertEquals(2, ProjectNameUtils.getEffectiveProjectNames("a\r\nb").size());
+        assertEquals(2, ProjectNameUtils.getEffectiveProjectNames("\ta\nb").size());
+        assertEquals(2, ProjectNameUtils.getEffectiveProjectNames("\r\na\n\tb\t").size());
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

User can input `JSESSIONID` in apollo portal's Cookie and a text contains multiple project names, then authorize them automaticlly.

![注册多个应用](https://user-images.githubusercontent.com/15523186/114401329-62a12780-9bd5-11eb-9270-c137116d20bf.png)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

Similar with #3

### Describe how to verify it

Test it manually.

### Special notes for reviews
