### PR TITLE
feat(dashboard): docs embed in sentinel dashboard server

### DIFF
--- a/sentinel-dashboard/pom.xml
+++ b/sentinel-dashboard/pom.xml
@@ -376,6 +376,12 @@
                     <exclude>resources/node_modules/**</exclude>
                 </excludes>
             </resource>
+
+            <!-- documentation -->
+            <resource>
+                <directory>../docs</directory>
+                <targetPath>docs</targetPath>
+            </resource>
         </resources>
     </build>
 </project>

--- a/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/config/DocumentationWebMvcConfigurer.java
+++ b/sentinel-dashboard/src/main/java/com/alibaba/csp/sentinel/dashboard/apollo/config/DocumentationWebMvcConfigurer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.csp.sentinel.dashboard.apollo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Let user can access documentation from sentinel dashboard.
+ *
+ * @see com.alibaba.csp.sentinel.dashboard.config.WebConfig#addResourceHandlers(ResourceHandlerRegistry) for UI resources
+ * @author wxq
+ */
+@Configuration
+public class DocumentationWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+
+        CacheControl cacheControl = CacheControl
+                .noStore()
+                ;
+
+        registry
+                .addResourceHandler("/docs/**")
+                .addResourceLocations("classpath:/docs/")
+                .setCacheControl(cacheControl)
+        ;
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/docs/").setViewName("forward:/docs/index.html");
+    }
+
+}

--- a/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
+++ b/sentinel-dashboard/src/main/webapp/resources/app/views/dashboard/home.html
@@ -479,6 +479,12 @@
             <h2 class="text-center" id="项目文档">
                 项目文档
             </h2>
+            <p>
+                请确保你在互联网环境下，访问文档，否则一些内容会无法正常显示
+            </p>
+            <p>
+                二维码可以使用手机扫描打开
+            </p>
         </div>
         <div class="col-md-3">
             <a href="https://anilople.github.io/Sentinel" target="_blank">
@@ -503,6 +509,18 @@
                     height="150"
                 />
             </a>
+        </div>
+        <div class="col-md-12">
+            <p>
+                如果不想访问最新版本的文档，
+            </p>
+            <p>
+                可以访问
+                <a href="docs/" target="_blank">当前版本的Sentinel控制台定制版文档</a>
+            </p>
+            <p>
+                这是嵌入在Sentinel控制台里面的文档，每个版本的Sentinel控制台都有一个对应版本的文档
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Embed  docs in sentinel dashboard server.

User can access document by sentinel dashboard.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

Add resource definition in `pom.xml`

```xml
            <!-- documentation -->
            <resource>
                <directory>../docs</directory>
                <targetPath>docs</targetPath>
            </resource>
```

So all contents under folder docs will be packaged in `sentinel-dashboard.jar` file.

### Describe how to verify it

Access UI manually.

### Special notes for reviews
